### PR TITLE
feat: Rule length monitoring

### DIFF
--- a/src/main/java/org/fordes/adfs/config/Config.java
+++ b/src/main/java/org/fordes/adfs/config/Config.java
@@ -22,6 +22,7 @@ public class Config {
 
     private Double faultTolerance = 0.0001;
     private Integer expectedQuantity = 2000000;
+    private Integer warnLimit = 6;
 
     @Bean
     public BloomFilter<String> bloomFilter() {

--- a/src/main/java/org/fordes/adfs/handler/LocalRuleHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/LocalRuleHandler.java
@@ -1,6 +1,7 @@
 package org.fordes.adfs.handler;
 
 import lombok.extern.slf4j.Slf4j;
+import org.fordes.adfs.config.Config;
 import org.fordes.adfs.enums.HandleType;
 import org.fordes.adfs.task.FileWriter;
 import org.fordes.adfs.util.BloomFilter;
@@ -25,8 +26,8 @@ import java.nio.file.StandardOpenOption;
 public class LocalRuleHandler extends RuleHandler {
 
     @Autowired
-    public LocalRuleHandler(BloomFilter<String> filter, FileWriter writer) {
-        super(filter, writer);
+    public LocalRuleHandler(BloomFilter<String> filter, FileWriter writer, Config config) {
+        super(filter, writer, config);
     }
 
     @Override

--- a/src/main/java/org/fordes/adfs/handler/RemoteRuleHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/RemoteRuleHandler.java
@@ -1,6 +1,7 @@
 package org.fordes.adfs.handler;
 
 import lombok.extern.slf4j.Slf4j;
+import org.fordes.adfs.config.Config;
 import org.fordes.adfs.enums.HandleType;
 import org.fordes.adfs.task.FileWriter;
 import org.fordes.adfs.util.BloomFilter;
@@ -25,8 +26,8 @@ public class RemoteRuleHandler extends RuleHandler {
             .build();
 
     @Autowired
-    public RemoteRuleHandler(BloomFilter<String> filter, FileWriter writer) {
-        super(filter, writer);
+    public RemoteRuleHandler(BloomFilter<String> filter, FileWriter writer, Config config) {
+        super(filter, writer, config);
     }
 
     @Override

--- a/src/main/java/org/fordes/adfs/handler/RuleHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/RuleHandler.java
@@ -2,6 +2,7 @@ package org.fordes.adfs.handler;
 
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.fordes.adfs.config.Config;
 import org.fordes.adfs.config.InputProperties;
 import org.fordes.adfs.enums.HandleType;
 import org.fordes.adfs.enums.RuleType;
@@ -30,6 +31,7 @@ public abstract class RuleHandler implements InitializingBean {
 
     protected BloomFilter<String> filter;
     protected FileWriter writer;
+    protected Config config;
     protected static final Map<HandleType, RuleHandler> handlerMap = new HashMap<>(HandleType.values().length);
 
     protected final void register(HandleType type, RuleHandler handler) {
@@ -75,6 +77,11 @@ public abstract class RuleHandler implements InitializingBean {
                                 }))
                         //写入阻塞队列
                         .ifPresent(e -> {
+
+                            if (original.length() <= config.getWarnLimit()) {
+                                log.warn("[{}] Suspicious rule => {}",prop.name(), original);
+                            }
+
                             filter.add(original);
                             effective.incrementAndGet();
                             writer.put(original, e.getValue());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ application:
   config:
     expected_quantity: 2000000  #预期规则数量
     fault_tolerance: 0.001 #容错率
+    warn_limit: 6 #警告阈值, 原始规则长度小于该值时会输出警告日志
 
   # 规则源配置，remote为远程规则，local为本地规则，支持多个规则源
   rule:


### PR DESCRIPTION
#24 还原  `warn_limit` 配置，原始规则长度小于该值时会输出警告日志：
```yaml
application.config.warn_limit: 6
```
