### PR TITLE
fix: 🐛 easylist处理错误

### DIFF
--- a/src/main/java/org/fordes/adfs/constant/Constants.java
+++ b/src/main/java/org/fordes/adfs/constant/Constants.java
@@ -47,6 +47,7 @@ public class Constants {
     public static final Set<String> LOCAL_IP = Set.of("0.0.0.0", "127.0.0.1", "::1");
     public static final Set<String> LOCAL_DOMAIN = Set.of("localhost", "localhost.localdomain", "local", "ip6-localhost", "ip6-loopback");
     public static final String LOCAL_V4 = "127.0.0.1";
+    public static final String UNKNOWN_IP = "0.0.0.0";
     public static final String LOCAL_V6 = "::1";
     public static final String LOCALHOST = "localhost";
     public static final String DOUBLE_AT = "@@";

--- a/src/main/java/org/fordes/adfs/constant/RegConstants.java
+++ b/src/main/java/org/fordes/adfs/constant/RegConstants.java
@@ -10,4 +10,5 @@ public class RegConstants {
     public static final Pattern PATTERN_PATH_ABSOLUTE = Pattern.compile("^[a-zA-Z]:([/\\\\].*)?");
     public static Pattern PATTERN_IP = Pattern.compile("((?:(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d)\\.){3}(?:25[0-5]|2[0-4]\\d|[01]?\\d?\\d))");
     public static Pattern PATTERN_DOMAIN = Pattern.compile("(?=^.{3,255}$)[a-zA-Z0-9][-a-zA-Z0-9]{0,62}(\\.[a-zA-Z0-9][-a-zA-Z0-9]{0,62})+$");
+    public static Pattern DOMAIN_PART = Pattern.compile("^([-a-zA-Z0-9]{0,62})+$");
 }

--- a/src/main/java/org/fordes/adfs/handler/RuleHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/RuleHandler.java
@@ -82,7 +82,7 @@ public abstract class RuleHandler implements InitializingBean {
                         });
             }
         } catch (Exception e) {
-            log.error("[{}] parser failed  => {}", prop.name(), e.getMessage());
+            log.error("[{}] parser failed  => {}\n", prop.name(), e.getMessage(), e);
         }
 
 

--- a/src/main/java/org/fordes/adfs/handler/rule/ClashHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/rule/ClashHandler.java
@@ -60,7 +60,7 @@ public final class ClashHandler extends Handler implements InitializingBean {
         }
 
         rule.setTarget(content);
-        rule.setDest(LOCAL_V4);
+        rule.setDest(UNKNOWN_IP);
         rule.setMode(Rule.Mode.DENY);
         rule.setScope(Rule.Scope.DOMAIN);
         if (rule.getType() == null) {

--- a/src/main/java/org/fordes/adfs/handler/rule/EasylistHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/rule/EasylistHandler.java
@@ -86,7 +86,7 @@ public final class EasylistHandler extends Handler implements InitializingBean {
                 rule.setSource(RuleSet.HOSTS);
                 rule.setTarget(entry.getValue());
                 rule.setMode(LOCAL_IP.contains(entry.getKey()) && !LOCAL_DOMAIN.contains(entry.getValue()) ? Rule.Mode.DENY : Rule.Mode.REWRITE);
-                rule.setDest(Rule.Mode.DENY.equals(rule.getMode()) ? entry.getValue() : entry.getKey());
+                rule.setDest(entry.getKey());
                 rule.setScope(Rule.Scope.DOMAIN);
                 rule.setType(Rule.Type.BASIC);
             } else {

--- a/src/main/java/org/fordes/adfs/handler/rule/EasylistHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/rule/EasylistHandler.java
@@ -78,7 +78,7 @@ public final class EasylistHandler extends Handler implements InitializingBean {
             rule.setScope(Rule.Scope.DOMAIN);
             rule.setTarget(origin);
             if (Rule.Mode.DENY.equals(rule.getMode())) {
-                rule.setDest(LOCAL_V4);
+                rule.setDest(UNKNOWN_IP);
             }
         }, e -> {
             Map.Entry<String, String> entry = Util.parseHosts(e);
@@ -86,7 +86,7 @@ public final class EasylistHandler extends Handler implements InitializingBean {
                 rule.setSource(RuleSet.HOSTS);
                 rule.setTarget(entry.getValue());
                 rule.setMode(LOCAL_IP.contains(entry.getKey()) && !LOCAL_DOMAIN.contains(entry.getValue()) ? Rule.Mode.DENY : Rule.Mode.REWRITE);
-                rule.setDest(entry.getKey());
+                rule.setDest(Rule.Mode.DENY == rule.getMode() ? UNKNOWN_IP : entry.getKey());
                 rule.setScope(Rule.Scope.DOMAIN);
                 rule.setType(Rule.Type.BASIC);
             } else {

--- a/src/main/java/org/fordes/adfs/handler/rule/HostsHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/rule/HostsHandler.java
@@ -33,7 +33,7 @@ public final class HostsHandler extends Handler implements InitializingBean {
         rule.setOrigin(line);
         rule.setTarget(entry.getValue());
         rule.setMode(LOCAL_IP.contains(entry.getKey()) && !LOCAL_DOMAIN.contains(entry.getValue()) ? Rule.Mode.DENY : Rule.Mode.REWRITE);
-        rule.setDest(entry.getKey());
+        rule.setDest(Rule.Mode.DENY == rule.getMode() ? UNKNOWN_IP : entry.getKey());
         rule.setScope(Rule.Scope.DOMAIN);
         rule.setType(Rule.Type.BASIC);
         return rule;
@@ -44,7 +44,7 @@ public final class HostsHandler extends Handler implements InitializingBean {
         if (Rule.Scope.DOMAIN == rule.getScope() &&
                 Rule.Type.BASIC == rule.getType() &&
                 Rule.Mode.ALLOW != rule.getMode()) {
-            return Optional.ofNullable(rule.getDest()).orElse(LOCAL_V4) + TAB + rule.getTarget();
+            return Optional.ofNullable(rule.getDest()).orElse(UNKNOWN_IP) + TAB + rule.getTarget();
         }
         return null;
     }

--- a/src/main/java/org/fordes/adfs/handler/rule/HostsHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/rule/HostsHandler.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.fordes.adfs.constant.Constants.*;
@@ -32,7 +33,7 @@ public final class HostsHandler extends Handler implements InitializingBean {
         rule.setOrigin(line);
         rule.setTarget(entry.getValue());
         rule.setMode(LOCAL_IP.contains(entry.getKey()) && !LOCAL_DOMAIN.contains(entry.getValue()) ? Rule.Mode.DENY : Rule.Mode.REWRITE);
-        rule.setDest(Rule.Mode.DENY.equals(rule.getMode()) ? entry.getValue() :entry.getKey());
+        rule.setDest(entry.getKey());
         rule.setScope(Rule.Scope.DOMAIN);
         rule.setType(Rule.Type.BASIC);
         return rule;
@@ -43,7 +44,7 @@ public final class HostsHandler extends Handler implements InitializingBean {
         if (Rule.Scope.DOMAIN == rule.getScope() &&
                 Rule.Type.BASIC == rule.getType() &&
                 Rule.Mode.ALLOW != rule.getMode()) {
-            return rule.getDest() + TAB + rule.getTarget();
+            return Optional.ofNullable(rule.getDest()).orElse(LOCAL_V4) + TAB + rule.getTarget();
         }
         return null;
     }

--- a/src/main/java/org/fordes/adfs/handler/rule/SmartdnsHandler.java
+++ b/src/main/java/org/fordes/adfs/handler/rule/SmartdnsHandler.java
@@ -54,7 +54,7 @@ public final class SmartdnsHandler extends Handler implements InitializingBean {
 
             rule.setType(domain.startsWith(ASTERISK) ? Rule.Type.WILDCARD : Rule.Type.BASIC);
             rule.setTarget(domain);
-            rule.setDest(LOCAL_V4);
+            rule.setDest(UNKNOWN_IP);
             rule.setScope(Rule.Scope.DOMAIN);
             return rule;
         }

--- a/src/main/java/org/fordes/adfs/model/Rule.java
+++ b/src/main/java/org/fordes/adfs/model/Rule.java
@@ -28,11 +28,21 @@ public class Rule {
      * 规则控制参数
      */
     public enum Control {
-        // 最高优先级
+        /**
+         * 最高优先级
+         */
         IMPORTANT,
 
-        //覆盖子域名
+        /**
+         * 覆盖子域名
+         */
+
         OVERLAY,
+
+        /**
+         * 限定符，通常是 ^
+         */
+        QUALIFIER,
 
         ;
     }


### PR DESCRIPTION
- easylist 转换错误添加 `^$domain=` 、优化通配域名的识别 (#29) 
- hosts 规则默认路由由 `127.0.0.0` 修改为 `0.0.0.0`